### PR TITLE
README clarifications and cleanups [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@
 
 ## Overview
 
-LittleTable is an emulator for Google [Cloud Bigtable](https://cloud.google.com/bigtable/) intended 
+LittleTable is an emulator for [Google Cloud Bigtable](https://cloud.google.com/bigtable/), intended
 to replace the emulator distributed with the `gcloud` utility.
 
 It aims to provide full compatibility with the Cloud Bigtable API,
-and fill the gaps left by the go based emulator, including support 
-for matching binary data with RE2 regexes and the `sink` filter.
+and fill the gaps in the Go-based emulator, such as the `sink` filter.
 
 ## Getting the emulator
 
 Maven:
-```
+```xml
 <dependency>
   <groupId>com.steveniemitz</groupId>
   <artifactId>littletable_2.12</artifactId>
@@ -25,22 +24,22 @@ Maven:
 ```
 
 Gradle:
-```
+```gradle
 compile 'com.steveniemitz:littletable_2.12:1.0.0'
 ```
 
 sbt:
-```
+```sbt
 libraryDependencies += "com.steveniemitz" %% "littletable" % "1.0.0"
 ```
 
 ### Other Dependencies
 
-LittleTable assumes you'll "bring your own" dependencies for gRPC as well as [bigtable-client-core](https://mvnrepository.com/artifact/com.google.cloud.bigtable/bigtable-client-core).
-By default `bigtable-client-core` will also include the required gRPC dependencies, so adding a
+LittleTable assumes you'll "bring your own" dependencies for gRPC as well as [`bigtable-client-core`](https://mvnrepository.com/artifact/com.google.cloud.bigtable/bigtable-client-core).
+By default, `bigtable-client-core` will also include the required gRPC dependencies, so adding a
 dependency to that is all that's required.
 
-See build.sbt for reasonable defaults.
+See [`build.sbt`](build.sbt) for reasonable defaults.
 
 ## Usage
  
@@ -50,7 +49,7 @@ emulator builder.  The builder can configure an in-process gRPC transport, or a 
 used.  For advanced usage, `BigtableEmulator.Builder.configureServerBuilder` can be used to 
 configure a user-provided gRPC server builder.
 
-```$scala
+```scala
 val emulator = 
   BigtableEmulator.newBuilder
     .withInProcess
@@ -64,4 +63,4 @@ val session = emulator.session
 val rows = session.getDataClient.readFlatRowsList(...)
 ```
 
-See the `BigtableTestSuite` for a full example.
+See the [`BigtableTestSuite`](src/test/scala/com/steveniemitz/littletable/BigtableTestSuite.scala) for a full example.


### PR DESCRIPTION
* the official Cloud Bigtable emulator now supports `\C` so it works with binary regexes
* fixed syntax highlighting for all code samples, including XML and Scala
* added missing code formatting / links as needed