### PR TITLE
Add version number to Maven badge [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # LittleTable
 
-## Status
 [![Build Status](https://travis-ci.org/steveniemitz/littletable.svg?branch=master)](https://travis-ci.org/steveniemitz/littletable)
-[![Maven Version](https://maven-badges.herokuapp.com/maven-central/com.steveniemitz/littletable/badge.svg)](http://search.maven.org/#search|gav|1|g:"com.steveniemitz")
+[![Maven Version](https://img.shields.io/maven-central/v/com.steveniemitz/littletable_2.12?label=littletable_2.12)](http://search.maven.org/#search|gav|1|g:"com.steveniemitz")
 
 ## Overview
 


### PR DESCRIPTION
Currently, the Maven badge shows "unknown" version number.
With this change, it automatically shows v1.0.0 for `littletable_2.12`.
Also set badge label to `littletable_2.12` instead of "maven central".
Kept the target URL as-is to be a search for all artifacts in group id.

Removed "Status" heading as it's pretty clear what these badges are for.